### PR TITLE
Implement OpenRouter services and agent skeleton

### DIFF
--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -5,3 +5,4 @@
 - Milestone 1 umgesetzt: Verzeichnisstruktur angelegt, Config/Logging-Module und DB-Init implementiert.
 - Milestone 2 begonnen: Einfaches GUI-Skelett mit Login und Dashboard erstellt. Benutzer koennen sich registrieren und einloggen, Projekte lassen sich anlegen.
 - Milestone 2 erweitert: Chatfenster und Code-Viewer als einfache Widgets umgesetzt. Dashboard oeffnet sie projektbezogen.
+- Milestone 3 begonnen: OpenRouter- und Claude-Flow-Services sowie Agenten-Grundklassen implementiert.

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -6,3 +6,4 @@
 
 - 2025-07-28: Milestone 2 begonnen: GUI-Skelett mit Login und Dashboard implementiert.
 - 2025-07-29: Chat- und Code-Viewer-Fenster hinzugefuegt. Dashboard startet sie fuer das ausgewaehlte Projekt.
+- 2025-07-30: Milestone 3 gestartet: Services fuer OpenRouter und Claude-Flow, Agentengeruest und Taskfunktionen hinzugefuegt.

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,5 @@
+from .config import Config
+from .logger import init_logging
+from .agents import Queen, HiveWorker
+
+__all__ = ["Config", "init_logging", "Queen", "HiveWorker"]

--- a/core/agents.py
+++ b/core/agents.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from db import create_task, update_task_status, add_code_file
+from services.openrouter import send_prompt
+
+
+class BaseAgent:
+    def __init__(self, conn, name: str) -> None:
+        self.conn = conn
+        self.name = name
+
+
+class Queen(BaseAgent):
+    """Simple project planning agent."""
+
+    def plan_project(self, project_id: int, idea: str) -> None:
+        response = send_prompt(
+            f"Create a numbered task list for the following project idea:\n{idea}\nReturn one task per line."
+        )
+        for line in response.splitlines():
+            line = line.strip()
+            if line:
+                create_task(self.conn, project_id, "hive", line)
+
+
+class HiveWorker(BaseAgent):
+    """Basic code generation worker."""
+
+    def execute_task(self, task_id: int, project_id: int, description: str) -> None:
+        code = send_prompt(description)
+        file_path = f"task_{task_id}.py"
+        add_code_file(self.conn, project_id, file_path, code)
+        update_task_status(self.conn, task_id, "done")

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -76,3 +76,45 @@ def get_code_files(conn: sqlite3.Connection, project_id: int) -> list[sqlite3.Ro
             (project_id,),
         )
     )
+
+def add_code_file(conn: sqlite3.Connection, project_id: int, path: str, content: str) -> None:
+    """Store a generated code file for a project."""
+    with conn:
+        conn.execute(
+            "INSERT INTO code_files (project_id, path, content) VALUES (?, ?, ?)",
+            (project_id, path, content),
+        )
+
+
+def create_task(
+    conn: sqlite3.Connection,
+    project_id: int,
+    agent: str,
+    description: str,
+    status: str = "pending",
+) -> int:
+    """Create a new task and return its ID."""
+    with conn:
+        cur = conn.execute(
+            "INSERT INTO tasks (project_id, agent, description, status) VALUES (?, ?, ?, ?)",
+            (project_id, agent, description, status),
+        )
+        return cur.lastrowid
+
+
+def get_tasks(conn: sqlite3.Connection, project_id: int) -> list[sqlite3.Row]:
+    return list(
+        conn.execute(
+            "SELECT id, agent, description, status FROM tasks WHERE project_id=?",
+            (project_id,),
+        )
+    )
+
+
+def update_task_status(conn: sqlite3.Connection, task_id: int, status: str) -> None:
+    with conn:
+        conn.execute(
+            "UPDATE tasks SET status=? WHERE id=?",
+            (status, task_id),
+        )
+

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,4 @@
+from .openrouter import send_prompt
+from .claude_flow import run_flow
+
+__all__ = ["send_prompt", "run_flow"]

--- a/services/claude_flow.py
+++ b/services/claude_flow.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import subprocess
+from typing import Iterable
+
+
+def run_flow(args: Iterable[str]) -> str:
+    """Run the Claude-Flow CLI and return its stdout."""
+    result = subprocess.run(list(args), capture_output=True, text=True, check=True)
+    return result.stdout

--- a/services/openrouter.py
+++ b/services/openrouter.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+import requests
+
+API_URL = "https://openrouter.ai/api/v1/chat/completions"
+DEFAULT_MODEL = "qwen/qwen3-coder:free"
+
+
+def load_api_key(path: Path = Path('.openrouter_key')) -> str:
+    """Return the stored OpenRouter API key."""
+    return Path(path).read_text().strip()
+
+
+def send_prompt(prompt: str, *, model: str = DEFAULT_MODEL, key_path: Path | str = '.openrouter_key') -> str:
+    """Send a prompt to the OpenRouter API and return the text response."""
+    api_key = load_api_key(Path(key_path))
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    response = requests.post(API_URL, headers=headers, json=payload, timeout=60)
+    response.raise_for_status()
+    data = response.json()
+    return data["choices"][0]["message"]["content"]


### PR DESCRIPTION
## Summary
- start milestone 3 work
- add OpenRouter and Claude-Flow service modules
- implement Queen and HiveWorker agent classes
- expose agents in `core.__init__`
- extend DB helpers for tasks and code files
- update changelog and brain log

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6886d5aea2a8832ea605dbdf8460de53