### PR TITLE
Add live agent status view

### DIFF
--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -14,3 +14,4 @@
 - TestWorker implementiert: Fuehrt Syntaxchecks nach jeder Codegenerierung aus
   und schreibt das Ergebnis ins Chatlog. Milestone 4 "Test-Tasks" damit
   abgeschlossen.
+- Live-Status-Anzeige fuer Agenten im Dashboard umgesetzt.

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -14,3 +14,4 @@
 - 2025-08-02: Automatisches Abhaken der Milestones implementiert.
 - 2025-08-03: TestWorker fuehrt nach jeder Codegenerierung einen Syntaxcheck
   aus und protokolliert das Ergebnis. Milestone 4 Test-Tasks abgeschlossen.
+- 2025-08-04: Live-Status-Anzeige fuer Agenten implementiert.

--- a/codex/daten/milestones.md
+++ b/codex/daten/milestones.md
@@ -25,7 +25,7 @@
 ## Milestone 5: Sprachsteuerung & erweiterte GUI
 - [x] STT-Modul fuer Spracheingabe integrieren
 - [x] Mikrofon-Button in der GUI
-- [ ] Live-Status der Agenten anzeigen
+- [x] Live-Status der Agenten anzeigen
 
 ## Milestone 6: Multi-Projekt und Benutzerrollen
 - [ ] Mehrere Projekte parallel verwalten

--- a/codex/update_milestones.py
+++ b/codex/update_milestones.py
@@ -18,7 +18,7 @@ DONE_PREFIXES = {
     "Chat-/Log-Ansicht": True,
     "STT-Modul": True,
     "Mikrofon-Button": True,
-    "Live-Status": False,
+    "Live-Status": True,
     "Mehrere Projekte parallel": False,
     "Rollen-/Rechtesystem": False,
     "Sicheres API-Key-Handling": True,

--- a/core/controller.py
+++ b/core/controller.py
@@ -19,6 +19,7 @@ class AIController:
         add_message(self.conn, project_id, "system", f"Starting project: {idea}")
         self.queen.plan_project(project_id, idea)
         for task in get_tasks(self.conn, project_id):
+            update_task_status(self.conn, task["id"], "running")
             code = self.worker.execute_task(task["id"], project_id, task["description"])
             test_id = create_task(
                 self.conn,

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -2,3 +2,12 @@ from .login import LoginWindow
 from .dashboard import Dashboard
 from .chat import ChatWindow
 from .codeviewer import CodeViewer
+from .status import StatusWindow
+
+__all__ = [
+    "LoginWindow",
+    "Dashboard",
+    "ChatWindow",
+    "CodeViewer",
+    "StatusWindow",
+]

--- a/gui/dashboard.py
+++ b/gui/dashboard.py
@@ -6,6 +6,7 @@ from db import create_project, get_projects
 from core import AIController
 from .chat import ChatWindow
 from .codeviewer import CodeViewer
+from .status import StatusWindow
 
 
 class Dashboard(QtWidgets.QMainWindow):
@@ -19,6 +20,7 @@ class Dashboard(QtWidgets.QMainWindow):
         self.new_btn = QtWidgets.QPushButton("New Project")
         self.chat_btn = QtWidgets.QPushButton("Open Chat")
         self.code_btn = QtWidgets.QPushButton("View Code")
+        self.status_btn = QtWidgets.QPushButton("View Status")
         self.run_btn = QtWidgets.QPushButton("Run AI")
 
         central = QtWidgets.QWidget()
@@ -29,12 +31,14 @@ class Dashboard(QtWidgets.QMainWindow):
         layout.addWidget(self.run_btn)
         layout.addWidget(self.chat_btn)
         layout.addWidget(self.code_btn)
+        layout.addWidget(self.status_btn)
         self.setCentralWidget(central)
 
         self.new_btn.clicked.connect(self.create_project)
         self.run_btn.clicked.connect(self.start_ai)
         self.chat_btn.clicked.connect(self.open_chat)
         self.code_btn.clicked.connect(self.open_code)
+        self.status_btn.clicked.connect(self.view_status)
         self.load_projects()
 
     def load_projects(self) -> None:
@@ -65,6 +69,12 @@ class Dashboard(QtWidgets.QMainWindow):
         project_id = self.selected_project_id()
         if project_id is not None:
             win = CodeViewer(self.conn, project_id)
+            win.show()
+
+    def view_status(self) -> None:
+        project_id = self.selected_project_id()
+        if project_id is not None:
+            win = StatusWindow(self.conn, project_id)
             win.show()
 
     def start_ai(self) -> None:

--- a/gui/status.py
+++ b/gui/status.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from PySide6 import QtWidgets, QtCore
+
+from db import get_tasks
+
+
+class StatusWindow(QtWidgets.QWidget):
+    """Display live status of all tasks for a project."""
+
+    def __init__(self, conn, project_id: int) -> None:
+        super().__init__()
+        self.conn = conn
+        self.project_id = project_id
+        self.setWindowTitle("Agent Status")
+
+        self.table = QtWidgets.QTableWidget()
+        self.table.setColumnCount(3)
+        self.table.setHorizontalHeaderLabels(["Agent", "Task", "Status"])
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(self.table)
+
+        self.timer = QtCore.QTimer(self)
+        self.timer.timeout.connect(self.load_status)
+        self.timer.start(1000)
+
+        self.load_status()
+
+    def load_status(self) -> None:
+        tasks = get_tasks(self.conn, self.project_id)
+        self.table.setRowCount(len(tasks))
+        for row_index, row in enumerate(tasks):
+            self.table.setItem(row_index, 0, QtWidgets.QTableWidgetItem(row["agent"]))
+            self.table.setItem(row_index, 1, QtWidgets.QTableWidgetItem(row["description"]))
+            self.table.setItem(row_index, 2, QtWidgets.QTableWidgetItem(row["status"]))
+


### PR DESCRIPTION
## Summary
- show agent statuses via new `StatusWindow`
- add button in dashboard to open the status view
- mark running tasks in `AIController`
- mark milestone complete
- update changelog and brain notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68871f997b54832e9857446f7c69c46e