### PR TITLE
Implement LAN project sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,18 @@ Installer-Pakete für Windows/Linux können generiert und veröffentlicht werden
 ## 📈 Geplante Features
 
 - [x] TTS für Sprachausgabe der Queen
-- [ ] Projekt-Sharing über LAN
+- [x] Projekt-Sharing über LAN
 - [x] Themes/Darkmode
 - [x] Plugin-System für eigene Agenten
+
+---
+
+## 📡 Projekt-Sharing über LAN
+
+Ein Projekt lässt sich direkt im lokalen Netzwerk teilen. Im Dashboard auf
+**"Share Project"** klicken. Daraufhin startet ein kleiner HTTP-Server und zeigt
+die URL zum ZIP-Archiv an. Jeder im gleichen LAN kann dieses Archiv im Browser
+herunterladen.
 
 ---
 

--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -23,3 +23,4 @@
 - Beispiel-Darkmode-Plugin erstellt und per Loader eingebunden.
 - TTS-Unterstuetzung fuer Chatnachrichten implementiert.
 - Build-Skript fuer PyInstaller hinzugefuegt.
+- LAN-Sharing umgesetzt: neuer Service zum Teilen eines Projekts als ZIP per HTTP und Share-Button im Dashboard.

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -19,3 +19,4 @@
   Rollen-/Rechtesystem (Admin/User) wurde integriert.
 - 2025-08-06: Milestone 7 gestartet: Plugin-System, Darkmode-Plugin, TTS und
   PyInstaller-Build-Skript hinzugefuegt.
+- 2025-08-07: LAN-Sharing implementiert: neuer Service `lan_share.py`, Share-Button im Dashboard, Dokumentation aktualisiert.

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,4 +1,5 @@
 from .openrouter import send_prompt
 from .claude_flow import run_flow
+from .lan_share import start_share, stop_share
 
-__all__ = ["send_prompt", "run_flow"]
+__all__ = ["send_prompt", "run_flow", "start_share", "stop_share"]

--- a/services/lan_share.py
+++ b/services/lan_share.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from tempfile import TemporaryDirectory
+from threading import Thread
+from pathlib import Path
+import zipfile
+from typing import Tuple
+
+from db import get_code_files
+
+
+def start_share(conn, project_id: int, host: str = "0.0.0.0", port: int = 8000) -> Tuple[HTTPServer, Thread, TemporaryDirectory, str]:
+    """Start a simple HTTP server to share project files as a ZIP archive.
+
+    Returns ``(server, thread, tempdir, url)``. The caller must keep the returned
+    ``TemporaryDirectory`` alive while the server is running and call
+    :func:`stop_share` afterwards.
+    """
+    tmpdir = TemporaryDirectory()
+    zip_path = Path(tmpdir.name) / f"project_{project_id}.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for row in get_code_files(conn, project_id):
+            zf.writestr(row["path"], row["content"] or "")
+
+    class Handler(SimpleHTTPRequestHandler):
+        def __init__(self, *args, directory: str = tmpdir.name, **kwargs):
+            super().__init__(*args, directory=directory, **kwargs)
+
+    httpd = HTTPServer((host, port), Handler)
+    thread = Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://{host}:{port}/{zip_path.name}"
+    return httpd, thread, tmpdir, url
+
+
+def stop_share(server: HTTPServer, thread: Thread, tmpdir: TemporaryDirectory) -> None:
+    """Stop the running share server and clean up temporary files."""
+    server.shutdown()
+    thread.join()
+    tmpdir.cleanup()


### PR DESCRIPTION
## Summary
- add `lan_share` service to serve project code as a ZIP via HTTP
- expose sharing helpers in `services/__init__`
- add Share Project button in the dashboard GUI
- document LAN sharing in README
- record progress in `brain.md` and `changelog.md`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python codex/update_milestones.py`

------
https://chatgpt.com/codex/tasks/task_e_68873240d174832e936dee2b2c8ca9e3