### PR TITLE
Add admin + settings GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Die Datenbank wird bei Erststart automatisch erzeugt.
 - **Task-Panel mit Agentenzuordnung**
 - **Code-Viewer mit Syntaxhighlighting**
 - **Mikrofonbutton für Spracheingabe**
+- **API-Key Einstellungen in der GUI**
 - **Adminpanel zur Benutzerverwaltung**
 
 ---

--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -24,3 +24,4 @@
 - TTS-Unterstuetzung fuer Chatnachrichten implementiert.
 - Build-Skript fuer PyInstaller hinzugefuegt.
 - LAN-Sharing umgesetzt: neuer Service zum Teilen eines Projekts als ZIP per HTTP und Share-Button im Dashboard.
+- Adminpanel und Settings-Fenster fuer API-Key implementiert.

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -20,3 +20,4 @@
 - 2025-08-06: Milestone 7 gestartet: Plugin-System, Darkmode-Plugin, TTS und
   PyInstaller-Build-Skript hinzugefuegt.
 - 2025-08-07: LAN-Sharing implementiert: neuer Service `lan_share.py`, Share-Button im Dashboard, Dokumentation aktualisiert.
+- 2025-08-08: Adminpanel und Settings-Fenster hinzugefuegt; Dokumentation ergaenzt.

--- a/codex/daten/docs.md
+++ b/codex/daten/docs.md
@@ -17,6 +17,8 @@
 - `db/` stellt Funktionen fuer den Zugriff auf die SQLite-Datenbank bereit
 - `services/` kapselt die Anbindung zu OpenRouter und Claude-Flow
 - `speech/` implementiert optionale Spracherkennung fuer Text-zu-Befehl
+- `plugins/` enthaelt Erweiterungen wie den Darkmode
+- `build.py` erstellt Installer
 
 ## API-Endpunkte und Prozesse
 ### OpenRouter
@@ -40,7 +42,10 @@
 ## Besonderheiten
 - Alle Daten bleiben lokal; keine Cloudspeicherung
 - API-Schluessel werden in einer Datei gesichert und niemals in den Code eingebettet
+- Passwoerter werden beim Speichern gehasht
 - Plugin-System ermoeglicht Erweiterungen (z.B. neue Agenten oder Funktionen)
 - TTS-Ausgabe fuer Rueckmeldungen der Queen
 - Beispiel-Plugin aktiviert Darkmode in der GUI
 - `build.py` baut Windows- und Linux-Installer via PyInstaller
+- `lan_share.py` ermoeglicht Projekt-Sharing ueber einen lokalen HTTP-Server
+- Adminpanel und Settings-Fenster sind in der GUI integriert

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -41,6 +41,17 @@ def authenticate_user(conn: sqlite3.Connection, username: str, password: str) ->
     return None, None
 
 
+def get_users(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    """Return all users sorted by ID."""
+    return list(conn.execute("SELECT id, username, role FROM users ORDER BY id"))
+
+
+def delete_user(conn: sqlite3.Connection, user_id: int) -> None:
+    """Delete the given user."""
+    with conn:
+        conn.execute("DELETE FROM users WHERE id=?", (user_id,))
+
+
 def create_project(
     conn: sqlite3.Connection,
     owner_id: int | None,

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -3,6 +3,8 @@ from .dashboard import Dashboard
 from .chat import ChatWindow
 from .codeviewer import CodeViewer
 from .status import StatusWindow
+from .admin import AdminWindow
+from .settings import SettingsWindow
 
 __all__ = [
     "LoginWindow",
@@ -10,4 +12,6 @@ __all__ = [
     "ChatWindow",
     "CodeViewer",
     "StatusWindow",
+    "AdminWindow",
+    "SettingsWindow",
 ]

--- a/gui/admin.py
+++ b/gui/admin.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from PySide6 import QtWidgets
+
+from db import get_users, delete_user
+
+
+class AdminWindow(QtWidgets.QWidget):
+    """Simple user management window for admins."""
+
+    def __init__(self, conn) -> None:
+        super().__init__()
+        self.conn = conn
+        self.setWindowTitle("User Management")
+
+        self.table = QtWidgets.QTableWidget()
+        self.table.setColumnCount(3)
+        self.table.setHorizontalHeaderLabels(["ID", "Username", "Role"])
+
+        self.refresh_btn = QtWidgets.QPushButton("Refresh")
+        self.delete_btn = QtWidgets.QPushButton("Delete")
+
+        btn_layout = QtWidgets.QHBoxLayout()
+        btn_layout.addWidget(self.refresh_btn)
+        btn_layout.addWidget(self.delete_btn)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(self.table)
+        layout.addLayout(btn_layout)
+
+        self.refresh_btn.clicked.connect(self.load_users)
+        self.delete_btn.clicked.connect(self.delete_selected)
+
+        self.load_users()
+
+    def load_users(self) -> None:
+        users = get_users(self.conn)
+        self.table.setRowCount(len(users))
+        for row_index, row in enumerate(users):
+            self.table.setItem(row_index, 0, QtWidgets.QTableWidgetItem(str(row["id"])))
+            self.table.setItem(row_index, 1, QtWidgets.QTableWidgetItem(row["username"]))
+            self.table.setItem(row_index, 2, QtWidgets.QTableWidgetItem(row["role"]))
+
+    def delete_selected(self) -> None:
+        row = self.table.currentRow()
+        if row < 0:
+            return
+        user_id_item = self.table.item(row, 0)
+        if user_id_item is None:
+            return
+        user_id = int(user_id_item.text())
+        delete_user(self.conn, user_id)
+        self.load_users()

--- a/gui/dashboard.py
+++ b/gui/dashboard.py
@@ -8,6 +8,8 @@ from services import start_share, stop_share
 from .chat import ChatWindow
 from .codeviewer import CodeViewer
 from .status import StatusWindow
+from .admin import AdminWindow
+from .settings import SettingsWindow
 
 
 class Dashboard(QtWidgets.QMainWindow):
@@ -26,6 +28,8 @@ class Dashboard(QtWidgets.QMainWindow):
         self.status_btn = QtWidgets.QPushButton("View Status")
         self.run_btn = QtWidgets.QPushButton("Run AI")
         self.share_btn = QtWidgets.QPushButton("Share Project")
+        self.settings_btn = QtWidgets.QPushButton("Settings")
+        self.admin_btn = QtWidgets.QPushButton("Admin Panel")
 
         central = QtWidgets.QWidget()
         layout = QtWidgets.QVBoxLayout(central)
@@ -37,6 +41,9 @@ class Dashboard(QtWidgets.QMainWindow):
         layout.addWidget(self.chat_btn)
         layout.addWidget(self.code_btn)
         layout.addWidget(self.status_btn)
+        layout.addWidget(self.settings_btn)
+        if role == "admin":
+            layout.addWidget(self.admin_btn)
         self.setCentralWidget(central)
 
         self.new_btn.clicked.connect(self.create_project)
@@ -45,6 +52,8 @@ class Dashboard(QtWidgets.QMainWindow):
         self.chat_btn.clicked.connect(self.open_chat)
         self.code_btn.clicked.connect(self.open_code)
         self.status_btn.clicked.connect(self.view_status)
+        self.settings_btn.clicked.connect(self.open_settings)
+        self.admin_btn.clicked.connect(self.open_admin)
         self.load_projects()
         self._share_server = None
 
@@ -104,6 +113,14 @@ class Dashboard(QtWidgets.QMainWindow):
         server, thread, tmpdir, url = start_share(self.conn, project_id)
         self._share_server = (server, thread, tmpdir)
         QtWidgets.QMessageBox.information(self, "Share", f"Project available at {url}\nServer stops when application closes")
+
+    def open_settings(self) -> None:
+        win = SettingsWindow()
+        win.exec()
+
+    def open_admin(self) -> None:
+        win = AdminWindow(self.conn)
+        win.show()
 
     def closeEvent(self, event) -> None:
         if self._share_server is not None:

--- a/gui/settings.py
+++ b/gui/settings.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from PySide6 import QtWidgets
+
+from services.openrouter import load_api_key, save_api_key
+
+
+class SettingsWindow(QtWidgets.QDialog):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Settings")
+
+        self.key_edit = QtWidgets.QLineEdit()
+        try:
+            self.key_edit.setText(load_api_key())
+        except Exception:
+            pass
+        save_btn = QtWidgets.QPushButton("Save")
+
+        layout = QtWidgets.QFormLayout(self)
+        layout.addRow("OpenRouter API Key", self.key_edit)
+        layout.addWidget(save_btn)
+
+        save_btn.clicked.connect(self.save)
+
+    def save(self) -> None:
+        save_api_key(self.key_edit.text())
+        QtWidgets.QMessageBox.information(self, "Settings", "Saved")
+        self.accept()

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,5 +1,5 @@
-from .openrouter import send_prompt
+from .openrouter import send_prompt, load_api_key, save_api_key
 from .claude_flow import run_flow
 from .lan_share import start_share, stop_share
 
-__all__ = ["send_prompt", "run_flow", "start_share", "stop_share"]
+__all__ = ["send_prompt", "load_api_key", "save_api_key", "run_flow", "start_share", "stop_share"]

--- a/services/openrouter.py
+++ b/services/openrouter.py
@@ -12,6 +12,11 @@ def load_api_key(path: Path = Path('.openrouter_key')) -> str:
     return Path(path).read_text().strip()
 
 
+def save_api_key(key: str, path: Path = Path('.openrouter_key')) -> None:
+    """Save the OpenRouter API key to the given path."""
+    Path(path).write_text(key.strip())
+
+
 def send_prompt(prompt: str, *, model: str = DEFAULT_MODEL, key_path: Path | str = '.openrouter_key') -> str:
     """Send a prompt to the OpenRouter API and return the text response."""
     api_key = load_api_key(Path(key_path))


### PR DESCRIPTION
## Summary
- add admin panel for user management
- allow storing the OpenRouter API key in a settings dialog
- export new functions from service layer
- document new GUI features and security details
- update changelog and brain log

## Testing
- `python codex/update_milestones.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6887377f69f0832ea2016d46c841b4dd