### PR TITLE
Add milestone updater plugin

### DIFF
--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -25,3 +25,5 @@
 - Build-Skript fuer PyInstaller hinzugefuegt.
 - LAN-Sharing umgesetzt: neuer Service zum Teilen eines Projekts als ZIP per HTTP und Share-Button im Dashboard.
 - Adminpanel und Settings-Fenster fuer API-Key implementiert.
+
+- Milestone-Updater-Plugin erstellt: aktualisiert milestones.md beim Start.

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -21,3 +21,5 @@
   PyInstaller-Build-Skript hinzugefuegt.
 - 2025-08-07: LAN-Sharing implementiert: neuer Service `lan_share.py`, Share-Button im Dashboard, Dokumentation aktualisiert.
 - 2025-08-08: Adminpanel und Settings-Fenster hinzugefuegt; Dokumentation ergaenzt.
+
+- 2025-08-09: Milestone-Updater-Plugin hinzugefuegt. Aktualisiert Milestones automatisch beim Programmstart.

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -7,7 +7,7 @@ Stelle sicher, dass in `codex/daten/milestones.md` jeder Milestone sowie alle se
 
 Aktueller Stand:
 - Arbeitsverzeichnis: `codex/daten/`
-- Aktueller Milestone: Milestone 1 aus `milestones.md`
+- Aktueller Milestone: Milestone 7 aus `milestones.md`
 - Letzte Aenderung: siehe obersten Eintrag in `changelog.md`
 
 Diese Datei ersetzt externe Prompts und dient als zentrale Eingabebasis fuer den naechsten Lauf.

--- a/plugins/milestones_updater.py
+++ b/plugins/milestones_updater.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex.update_milestones import update_file
+
+
+class Plugin:
+    """Plugin to automatically update milestones on startup."""
+
+    def register(self, app) -> None:  # pragma: no cover - side effect
+        update_file(Path("codex/daten/milestones.md"))


### PR DESCRIPTION
## Summary
- create plugin to auto-update milestones on startup
- log milestone updater change
- document plugin in brain and update milestone status
- mark latest milestone in the prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68873e8dcb84832eb415d705faea2737