### PR TITLE
Plan workspace feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Die Software führt ein ganzes KI-Entwicklungsteam – eine Projektleiterin-KI (
 - **Claude-Flow Orchestrierung**: Nutzung der Hive-/Swarm-Architektur für verteilte Agentenarbeit.
 - **Sprachsteuerung (optional)**: Eingabe auch per Mikrofon mit STT.
 - **Code-Browser & Export**: Alle generierten Dateien einsehbar und exportierbar.
+- 📂 **Live-Projekt-Workspace & ZIP-Export**
+  Während die KI-Agenten ein neues Programm erzeugen, entstehen die Dateien live in einem sichtbaren Projektordner.
+  Sobald das Projekt abgeschlossen ist, kann es direkt aus der App als ZIP-Datei exportiert werden.
 - **Plattformübergreifend**: Läuft auf Windows & Linux als PySide6 Desktop-App.
 
 ---

--- a/codex/daten/docs.md
+++ b/codex/daten/docs.md
@@ -49,3 +49,10 @@
 - `build.py` baut Windows- und Linux-Installer via PyInstaller
 - `lan_share.py` ermoeglicht Projekt-Sharing ueber einen lokalen HTTP-Server
 - Adminpanel und Settings-Fenster sind in der GUI integriert
+
+## Projekt-Workspace & ZIP-Export
+- Alle generierten Dateien liegen in einem zentralen Ordner `workspace/`.
+- Jeder KI-Lauf legt darunter einen Unterordner mit `<projektname-timestamp>` an.
+- Die GUI zeigt den Ordner mit `QFileSystemModel` live an und aktualisiert sich bei Änderungen.
+- Beim Anklicken einer Datei öffnet sich ein schreibgeschützter Editor mit Syntaxhighlighting.
+- Über einen Export-Button wird der Projektordner mit `shutil.make_archive` als ZIP gepackt und kann gespeichert werden.

--- a/codex/daten/milestones.md
+++ b/codex/daten/milestones.md
@@ -54,5 +54,15 @@
 - [ ] Schalter in den Einstellungen zum Aktivieren/Deaktivieren
 
 ## Milestone 11: Agenten-Plugin-System
-- [ ] Plugin-Schnittstelle erweitern, um neue Agenten einzubinden
+- [x] Plugin-Schnittstelle erweitern, um neue Agenten einzubinden
 - [ ] Beispielplugin fuer einen Custom-Agent bereitstellen
+
+## Milestone 12: Live-Projekt-Workspace & ZIP-Export
+- [ ] Zentrales Verzeichnis `workspace/` anlegen
+- [ ] Unterordner `<projektname-timestamp>` bei jedem Agentenlauf erstellen
+- [ ] Dateibaum in der GUI mit `QFileSystemModel` live anzeigen
+- [ ] Dateien per Klick in schreibgeschütztem Editor mit Syntaxhighlighting öffnen
+- [ ] Änderungen am Workspace in Echtzeit verfolgen
+- [ ] Projektordner über einen Button als ZIP exportieren
+- [ ] Archivierung mit `shutil.make_archive` implementieren
+- [ ] Pfadverwaltung und DB-Eintrag für den Workspace ergänzen

--- a/prompt.md
+++ b/prompt.md
@@ -1,0 +1,1 @@
+Codex, beginne mit der Umsetzung des Projekt-Workspace-Features aus Milestone 12. Implementiere zuerst die Verzeichnisstruktur, die Live-Dateiansicht und den ZIP-Export.


### PR DESCRIPTION
## Summary
- add Live-Projekt-Workspace & ZIP-Export feature to README
- document workspace feature in docs
- outline milestone for workspace and zip export
- add prompt for next run

## Testing
- `python codex/update_milestones.py`

------
https://chatgpt.com/codex/tasks/task_e_688740fe1f04832e8259a24c8777ffef