### PR TITLE
Add planning for Zauberstab feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Die Software führt ein ganzes KI-Entwicklungsteam – eine Projektleiterin-KI (
   Zu Beginn erzeugt die Queen aus der Nutzeridee eine vollständige Projekt-Roadmap.  
   Diese kann live eingesehen werden – inkl. aller Zwischenstände.  
   Änderungen können jederzeit im Dialog mit der Queen (Text oder Sprache) besprochen und übernommen werden.
+- 🪄 **Zauberstab – automatische Feature-Innovation**
+  Mit einem Klick analysiert die Queen das bestehende Projekt und schlägt neue kreative Funktionen vor.
+  Diese können direkt in die Roadmap übernommen und anschließend umgesetzt werden.
 - **Code-Browser & Export**: Alle generierten Dateien einsehbar und exportierbar.
 - 📂 **Live-Projekt-Workspace & ZIP-Export**
   Während die KI-Agenten ein neues Programm erzeugen, entstehen die Dateien live in einem sichtbaren Projektordner.

--- a/codex/daten/docs.md
+++ b/codex/daten/docs.md
@@ -64,3 +64,12 @@
 - Änderungen durch die Queen aktualisieren sowohl die JSON-Datei als auch die Datenbank.
 - In der GUI erscheint eine eigene Ansicht (z. B. Sidebar mit `QTreeView`), die den aktuellen Stand der Roadmap live anzeigt.
 - Nutzer können per Chat oder Spracheingabe Änderungswünsche einreichen; nach Bestätigung passt die Queen die Roadmap an und speichert sie erneut.
+
+## Zauberstab - automatische Feature-Innovation
+- In der GUI erscheint ein 🪄-Icon mit Tooltip "Lass die Queen neue Features vorschlagen".
+- Beim Klick analysiert die Queen die aktuelle Codebasis im Ordner `workspace/` und liest `milestones.md`.
+- Aus diesen Informationen entwickelt sie 2–5 kreative Funktionsideen mit kurzer Beschreibung und Nutzenargumentation.
+- Die Ideen werden in einem separaten Panel aufgelistet, jeweils mit Button "Zur Roadmap hinzufügen".
+- Akzeptierte Vorschläge schreibt die Queen als neuen Milestone samt Subtasks direkt in `milestones.md` und legt optional Notizen in `brain.md` ab.
+- Der gesamte Ablauf wird im Chat und den Logs dokumentiert und lässt sich später nachvollziehen.
+

--- a/codex/daten/milestones.md
+++ b/codex/daten/milestones.md
@@ -77,3 +77,14 @@
 - [ ] Änderungswünsche lassen sich über Chat oder Spracheingabe einreichen.
 - [ ] Nach Bestätigung durch die Queen wird die Roadmap angepasst und erneut
   gespeichert.
+
+## Milestone 14: Zauberstab - automatische Feature-Innovation
+- [ ] Zauberstab-Icon (🪄) in der GUI mit Tooltip "Lass die Queen neue Features vorschlagen"
+- [ ] Klick analysiert Codebasis unter `workspace/` sowie `milestones.md`
+- [ ] Queen entwickelt daraus 2–5 neue Feature-Ideen inkl. Nutzenbeschreibung
+- [ ] Ideen erscheinen in einem Panel mit Button "Zur Roadmap hinzufügen"
+- [ ] Akzeptierte Vorschläge werden als neuer Milestone mit Subtasks in `milestones.md` eingetragen
+- [ ] Optional Notizen zu den Features in `brain.md` speichern
+- [ ] Ergebnis und Aktionen im Chat/Log dokumentieren
+- [ ] Tests und Dokumentation der Funktion anlegen
+

--- a/prompt.md
+++ b/prompt.md
@@ -1,6 +1,6 @@
-Codex, beginne mit der Umsetzung des neuen Roadmap-Systems aus Milestone 13.
+Codex, beginne mit der Umsetzung des Zauberstab-Features aus Milestone 14.
 Fokus:
-- Automatische Konzept- und Roadmap-Erstellung durch die Queen bei jeder Projektidee
-- Speicherung der Roadmap als JSON sowie Eintrag in der Datenbank
-- Live-Ansicht der Roadmap in der GUI
-- Änderungsdialog per Chat oder Spracheingabe, der die Roadmap nach Bestätigung anpasst
+- Zauberstab-Icon in der GUI integrieren
+- Analyse der Codebasis und Roadmap durch die Queen
+- Anzeige von Feature-Vorschlägen mit Option, sie direkt in milestones.md zu übernehmen
+- Automatische Erstellung neuer Milestones bei Auswahl


### PR DESCRIPTION
## Summary
- plan new **Zauberstab** feature in milestones
- document the idea in docs
- describe the magic feature in README
- update prompt to start implementation next

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688745616a4c832ebda9a927c4986229