### PR TITLE
Implement Code-Viewer highlighting and save option

### DIFF
--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -33,3 +33,4 @@
   - Erweiterbare Agenten via Plugin-Schnittstelle
 - Neue Milestones 8 bis 11 entsprechend angelegt.
 - Milestone 8 gestartet: Dashboard erhielt Pause/Resume und Task-Manager, AIController verfuegt nun ueber Pausenlogik.
+- Milestone 9 abgeschlossen: Python-Code wird im Code-Viewer farbig hervorgehoben und einzelne Dateien koennen gespeichert werden.

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -24,3 +24,4 @@
 - 2025-08-09: Milestone-Updater-Plugin hinzugefuegt. Aktualisiert Milestones automatisch beim Programmstart.
 - 2025-08-09: Konzeptpruefung abgeschlossen. Fehlende Funktionen ermittelt und Milestones 8-11 angelegt (Live-Steuerung, Code-Highlighting, Queen-TTS, Agenten-Plugins).
 - 2025-08-10: Milestone 8 begonnen: AIController pausierbar, Dashboard mit Pause/Resume-Buttons und Task-Manager.
+- 2025-08-11: Milestone 9 umgesetzt: Code-Viewer mit Syntaxhighlighting und Einzeldatei-Export.

--- a/codex/daten/milestones.md
+++ b/codex/daten/milestones.md
@@ -46,8 +46,8 @@
 - [x] AIController um Pausen-Logik erweitern
 
 ## Milestone 9: Verbesserter Code-Viewer
-- [ ] Syntaxhighlighting fuer Python-Code implementieren
-- [ ] Option zum Speichern einzelner Dateien
+- [x] Syntaxhighlighting fuer Python-Code implementieren
+- [x] Option zum Speichern einzelner Dateien
 
 ## Milestone 10: Automatische Queen-TTS
 - [ ] Queen-Nachrichten automatisch ueber TTS ausgeben

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -51,4 +51,4 @@ Deine Aufgabe ist es jetzt, mit der **technischen Umsetzung der geplanten Funkti
 
 ---
 
-[Codex aktiviert – fahre fort mit Milestone 9 (Verbesserter Code-Viewer)]
+[Codex aktiviert – fahre fort mit Milestone 10 (Automatische Queen-TTS)]

--- a/gui/codeviewer.py
+++ b/gui/codeviewer.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from PySide6 import QtWidgets
 
+from .python_highlighter import PythonHighlighter
+
 from db import get_code_files
 
 
@@ -13,15 +15,23 @@ class CodeViewer(QtWidgets.QMainWindow):
         self.setWindowTitle("Code Viewer")
 
         self.file_list = QtWidgets.QListWidget()
+        self.save_btn = QtWidgets.QPushButton("Save File")
         self.editor = QtWidgets.QPlainTextEdit(readOnly=True)
+        self.highlighter = PythonHighlighter(self.editor.document())
 
         central = QtWidgets.QWidget()
         layout = QtWidgets.QHBoxLayout(central)
-        layout.addWidget(self.file_list)
+
+        left_layout = QtWidgets.QVBoxLayout()
+        left_layout.addWidget(self.file_list)
+        left_layout.addWidget(self.save_btn)
+
+        layout.addLayout(left_layout)
         layout.addWidget(self.editor)
         self.setCentralWidget(central)
 
         self.file_list.itemSelectionChanged.connect(self.display_file)
+        self.save_btn.clicked.connect(self.save_file)
         self.load_files()
 
     def load_files(self) -> None:
@@ -35,3 +45,17 @@ class CodeViewer(QtWidgets.QMainWindow):
         if row >= 0:
             data = self.files[row]
             self.editor.setPlainText(data["content"] or "")
+
+    def save_file(self) -> None:
+        row = self.file_list.currentRow()
+        if row < 0:
+            return
+        data = self.files[row]
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(self, "Save File", data["path"])
+        if path:
+            try:
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(data["content"] or "")
+                QtWidgets.QMessageBox.information(self, "Save File", "File saved")
+            except Exception as exc:
+                QtWidgets.QMessageBox.warning(self, "Save File", str(exc))

--- a/gui/python_highlighter.py
+++ b/gui/python_highlighter.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from PySide6 import QtGui, QtCore
+
+
+class PythonHighlighter(QtGui.QSyntaxHighlighter):
+    """Very small syntax highlighter for Python code."""
+
+    KEYWORDS = [
+        'False', 'class', 'finally', 'is', 'return',
+        'None', 'continue', 'for', 'lambda', 'try',
+        'True', 'def', 'from', 'nonlocal', 'while',
+        'and', 'del', 'global', 'not', 'with',
+        'as', 'elif', 'if', 'or', 'yield',
+        'assert', 'else', 'import', 'pass',
+        'break', 'except', 'in', 'raise',
+    ]
+
+    def __init__(self, document: QtGui.QTextDocument) -> None:
+        super().__init__(document)
+        self.rules: list[tuple[QtCore.QRegularExpression, QtGui.QTextCharFormat]] = []
+
+        keyword_format = QtGui.QTextCharFormat()
+        keyword_format.setForeground(QtGui.QColor("blue"))
+        for word in self.KEYWORDS:
+            pattern = QtCore.QRegularExpression(rf"\b{word}\b")
+            self.rules.append((pattern, keyword_format))
+
+        string_format = QtGui.QTextCharFormat()
+        string_format.setForeground(QtGui.QColor("magenta"))
+        self.rules.append((QtCore.QRegularExpression(r"'[^'\\n]*'"), string_format))
+        self.rules.append((QtCore.QRegularExpression(r'"[^"\\n]*"'), string_format))
+
+        comment_format = QtGui.QTextCharFormat()
+        comment_format.setForeground(QtGui.QColor("darkgreen"))
+        self.rules.append((QtCore.QRegularExpression(r"#.*"), comment_format))
+
+    def highlightBlock(self, text: str) -> None:  # pragma: no cover - GUI
+        for pattern, fmt in self.rules:
+            it = pattern.globalMatch(text)
+            while it.hasNext():
+                match = it.next()
+                self.setFormat(match.capturedStart(), match.capturedLength(), fmt)
+


### PR DESCRIPTION
## Summary
- highlight Python code in CodeViewer
- allow saving files from CodeViewer
- update milestones for completed Milestone 9
- log the milestone in changelog and brain
- switch prompt to next milestone

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68874f1e44d4832e81f4fab31c7f54d0