### PR TITLE
Run final tests and refactor LAN share API

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -30,3 +30,4 @@
 - 2025-08-14: Milestone 12 umgesetzt: Projekt-Workspace mit Live-Dateibaum und ZIP-Export hinzugefügt.
 - 2025-08-15: Milestone 13 umgesetzt: dynamische Roadmap mit GUI-Ansicht und Chat-Integration.
 - 2025-08-16: Milestone 14 gestartet: Zauberstab-Feature und Feature Wizard hinzugefügt.
+- 2025-08-17: Abschließende Tests durchgeführt und Refactoring des LAN-Sharing-Service.

--- a/gui/dashboard.py
+++ b/gui/dashboard.py
@@ -184,9 +184,13 @@ class Dashboard(QtWidgets.QMainWindow):
         if self._share_server is not None:
             QtWidgets.QMessageBox.information(self, "Share", "Project is already being shared")
             return
-        server, thread, tmpdir, url = start_share(self.conn, project_id)
-        self._share_server = (server, thread, tmpdir)
-        QtWidgets.QMessageBox.information(self, "Share", f"Project available at {url}\nServer stops when application closes")
+        info = start_share(self.conn, project_id)
+        self._share_server = info
+        QtWidgets.QMessageBox.information(
+            self,
+            "Share",
+            f"Project available at {info.url}\nServer stops when application closes",
+        )
 
     def open_settings(self) -> None:
         win = SettingsWindow()
@@ -219,6 +223,6 @@ class Dashboard(QtWidgets.QMainWindow):
 
     def closeEvent(self, event) -> None:
         if self._share_server is not None:
-            stop_share(*self._share_server)
+            stop_share(self._share_server)
             self._share_server = None
         super().closeEvent(event)


### PR DESCRIPTION
## Summary
- run tests to ensure all milestones pass
- refactor `lan_share.py` to return a NamedTuple for clarity
- update `Dashboard` to use new API
- update changelog with final tests entry

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688764ba1098832ea371ef7fe544fa24