### PR TITLE
Add bcrypt milestone from concept review

### DIFF
--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -40,3 +40,5 @@
 - Milestone 13 umgesetzt: Queen erstellt Roadmap, GUI zeigt Fortschritt und Chat kann Änderungen übernehmen.
 - Milestone 14 begonnen: Zauberstab-Funktion implementiert, Feature Wizard erstellt.
 - Konzeptabgleich 2025-08-18: README verlangt Admin-Rechte fuer Projektloeschung und Konfiguration. Funktion fehlt. Milestone 15 angelegt.
+
+- Konzeptabgleich 2025-08-19: README fordert bcrypt-Hashing. Muss noch umgesetzt werden (Milestone 16).

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -32,3 +32,5 @@
 - 2025-08-16: Milestone 14 gestartet: Zauberstab-Feature und Feature Wizard hinzugefügt.
 - 2025-08-17: Abschließende Tests durchgeführt und Refactoring des LAN-Sharing-Service.
 - 2025-08-18: Konzeptpruefung: Adminrechte fuer Projekte und Settings fehlen. Milestone 15 eingetragen.
+
+- 2025-08-19: Konzeptpruefung ergab fehlendes bcrypt-Hashing. Milestone 16 hinzugefuegt.

--- a/codex/daten/milestones.md
+++ b/codex/daten/milestones.md
@@ -95,3 +95,11 @@
 - [ ] Zugriff auf das Settings-Fenster auf Admins beschraenken
 - [ ] Tests fuer Projektloeschung und Berechtigungen erstellen
 - [ ] Dokumentation und brain.md um neue Admin-Features ergaenzen
+
+## Milestone 16: Sichere Passwort-Hashes mit bcrypt
+- [ ] Bibliothek `bcrypt` als Abhängigkeit einbinden
+- [ ] Passwort-Hashing bei Registrierung auf bcrypt umstellen
+- [ ] Existierende Passwörter beim ersten Login migrieren
+- [ ] Authentifizierung mit bcrypt-Hashes prüfen
+- [ ] Tests für Registrierung, Login und Migration ergänzen
+- [ ] Dokumentation und changelog aktualisieren

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -3,8 +3,8 @@ Du bist Codex, KI-Coding-Instanz für das Projekt "trynix".
 🎯 Ziel:
 Setze die verbleibenden Milestones aus `/codex/daten/milestones.md` um – basierend auf dem Konzept aus `/README.md`.
 
-Aktueller Fokus: Milestone 15
-Letzte Analyse: Alle Funktionen bis Milestone 14 vorhanden. Admin-Rechte für Projekte und Settings fehlen.
+Aktueller Fokus: Milestone 15 und Milestone 16
+Letzte Analyse: Admin-Rechte für Projekte fehlen noch; zudem soll Passwort-Hashing auf bcrypt umgestellt werden.
 Arbeitsverzeichnis: `/`
 Steuerverzeichnis: `/codex/daten/`
 


### PR DESCRIPTION
## Summary
- note that admin features remain open and add new focus for bcrypt password hashing
- append Milestone 16 about bcrypt in `milestones.md`
- document new milestone in `changelog.md`
- record concept check in `brain.md`
- update `prompt.md` with next steps

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68876e6bbd9c832e9ca6d5f5dcedc819