### PR TITLE
Plan agent/tool engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Die Software führt ein ganzes KI-Entwicklungsteam – eine Projektleiterin-KI (
 - 📂 **Live-Projekt-Workspace & ZIP-Export**
   Während die KI-Agenten ein neues Programm erzeugen, entstehen die Dateien live in einem sichtbaren Projektordner.
   Sobald das Projekt abgeschlossen ist, kann es direkt aus der App als ZIP-Datei exportiert werden.
+- 🧠 **Eigene KI-Agenten & Tools**
+  Die App bietet eine grafische Oberfläche zum Erstellen neuer Agenten und deren Werkzeuge.
+  Diese Agenten können spezialisierte Aufgaben übernehmen und nahtlos mit der Queen zusammenarbeiten.
 - **Plattformübergreifend**: Läuft auf Windows & Linux als PySide6 Desktop-App.
 
 ---

--- a/codex/daten/docs.md
+++ b/codex/daten/docs.md
@@ -81,3 +81,8 @@
 - Akzeptierte Vorschläge werden als neuer Milestone samt Subtasks an `milestones.md` angehängt und optional als Notiz in `brain.md` vermerkt.
 - Der gesamte Ablauf wird im Chat und den Logs dokumentiert und lässt sich später nachvollziehen.
 
+## Eigene Agenten & Tools
+Neue Agenten werden als Python-Klassen definiert, die `BaseAgent` erweitern. Eine YAML-Datei `agents.yaml` speichert Name, Beschreibung, Spezialisierung und optionale Fähigkeiten. Beim Start lädt ein Plugin diese Datei, erzeugt entsprechende Agentenklassen und meldet sie über `register_agent()` im System an.
+
+Tools sind ebenfalls per YAML konfigurierbar. Jede Definition enthält `name`, `description`, `command` und optionale Eingabeparameter. Die Agentenkonfiguration legt fest, welche Tools ein Agent verwenden darf. Beim Laden registriert das Plugin die Tools und ordnet sie den Agenten zu.
+

--- a/codex/daten/milestones.md
+++ b/codex/daten/milestones.md
@@ -103,3 +103,23 @@
 - [ ] Authentifizierung mit bcrypt-Hashes prüfen
 - [ ] Tests für Registrierung, Login und Migration ergänzen
 - [ ] Dokumentation und changelog aktualisieren
+
+## Milestone 17: Agenten-Erstellung
+- [ ] Dialog "Agent anlegen" in der GUI bereitstellen
+- [ ] Backend-Routinen zum Speichern neuer Agenten (DB oder YAML)
+- [ ] Eingaben: Name, Beschreibung, Spezialisierung, Fähigkeiten
+- [ ] Validierung und Tests der Eingaben
+
+## Milestone 18: Tool-Baukasten & Registrierung
+- [ ] Editor zum Definieren neuer Tools (Name, Beschreibung, Kommando, Parameter)
+- [ ] Tools persistent speichern und beim App-Start laden
+- [ ] Zuordnung von Tools zu Agenten in der UI ermöglichen
+- [ ] Registrierung der Tools im System prüfen
+- [ ] Tests für Tool-Verwaltung und -Zuordnung
+
+## Milestone 19: Integration in Queen- und Agentensystem
+- [ ] Queen lädt neue Agenten automatisch und aktiviert sie
+- [ ] Deaktivierung einzelner Agenten über die GUI
+- [ ] Controller erlaubt dynamische Auswahl aller registrierten Agenten
+- [ ] Dokumentation aktualisieren und Beispiele ergänzen
+

--- a/prompt.md
+++ b/prompt.md
@@ -1,6 +1,1 @@
-Codex, beginne mit der Umsetzung des Live-Projekt-Workspace-Features aus Milestone 12.
-Fokus:
-- Zentrales Verzeichnis `workspace/` anlegen und Unterordner je Projekt erzeugen
-- Live-Dateiansicht mit `QFileSystemModel` in der GUI
-- Dateien schreibgeschuetzt im Editor darstellen
-- ZIP-Export des Projektordners implementieren
+Beginne mit der Umsetzung der neuen Agenten- und Tool-Engine ab dem nächsten Lauf.


### PR DESCRIPTION
## Summary
- outline ability to create custom agents and tools in documentation
- add milestones for UI/Backend agent creation, tool management and registration
- highlight new feature in README
- set prompt to start implementing the new system

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688770545a00832eaf0f505535cb6ac0