### PR TITLE
Implement context engine

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -46,3 +46,4 @@
 - 2025-08-25: Milestone 19 umgesetzt: Controller lädt registrierte Agenten
   dynamisch, Dashboard erlaubt Aktivieren und Deaktivieren. Dokumentation
   aktualisiert.
+- 2025-08-26: Milestone 20 umgesetzt: zentrale Kontext-Engine mit JSON-Datei, optionaler DB-Speicherung und GUI-Viewer implementiert.

--- a/codex/daten/docs.md
+++ b/codex/daten/docs.md
@@ -101,3 +101,4 @@ Die Anwendung verwaltet alle relevanten Zustände in einer globalen Kontextstruk
 - `user_actions` – manuelle Eingriffe und Entscheidungen des Nutzers
 
 Die Struktur wird bei jedem Ereignis automatisch fortgeschrieben und lässt sich über eine API lesen oder aktualisieren. Optional können die Daten zusätzlich in der Datenbank gesichert werden.
+Ein kleines Fenster in der GUI zeigt den Inhalt von `context_state.json` live an.

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -3,6 +3,12 @@ from .logger import init_logging
 from .agents import Queen, HiveWorker
 from .controller import AIController
 from .roadmap import load_roadmap, save_roadmap, mark_task_done
+from .context import (
+    ContextState,
+    load_context,
+    save_context,
+    append_entry,
+)
 
 __all__ = [
     "Config",
@@ -15,4 +21,8 @@ __all__ = [
     "load_roadmap",
     "save_roadmap",
     "mark_task_done",
+    "ContextState",
+    "load_context",
+    "save_context",
+    "append_entry",
 ]

--- a/core/context.py
+++ b/core/context.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict, field
+from pathlib import Path
+from typing import Any, Dict
+import sqlite3
+import json
+
+CONTEXT_FILE = Path("context_state.json")
+
+
+@dataclass
+class ContextState:
+    """Data container for the global application context."""
+
+    history: list = field(default_factory=list)
+    agents: Dict[str, Any] = field(default_factory=dict)
+    task_flow: list = field(default_factory=list)
+    handoffs: list = field(default_factory=list)
+    user_actions: list = field(default_factory=list)
+
+
+DEFAULT_STATE = ContextState()
+
+
+def load_context(path: Path = CONTEXT_FILE, conn: sqlite3.Connection | None = None) -> ContextState:
+    """Load context state from JSON file or DB."""
+    if conn is not None:
+        from db import load_context_db
+
+        data_json = load_context_db(conn)
+        data = json.loads(data_json) if data_json else {}
+    elif path.exists():
+        data = json.loads(path.read_text(encoding="utf-8"))
+    else:
+        data = {}
+    base = asdict(DEFAULT_STATE)
+    base.update(data)
+    return ContextState(**base)
+
+
+def save_context(
+    state: ContextState,
+    path: Path = CONTEXT_FILE,
+    conn: sqlite3.Connection | None = None,
+) -> None:
+    """Save context state to JSON file and optionally DB."""
+    data = json.dumps(asdict(state), indent=2)
+    path.write_text(data, encoding="utf-8")
+    if conn is not None:
+        from db import save_context_db
+
+        save_context_db(conn, data)
+
+
+def append_entry(
+    section: str,
+    entry: Any,
+    path: Path = CONTEXT_FILE,
+    conn: sqlite3.Connection | None = None,
+) -> ContextState:
+    """Append an entry to a section and persist the state."""
+    state = load_context(path, conn)
+    if not hasattr(state, section):
+        raise ValueError(f"Unknown section: {section}")
+    attr = getattr(state, section)
+    if section == "agents" and isinstance(entry, dict):
+        attr.update(entry)
+    else:
+        attr.append(entry)
+    setattr(state, section, attr)
+    save_context(state, path, conn)
+    return state

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -222,3 +222,20 @@ def update_task_description(
             (description, task_id),
         )
 
+
+def save_context_db(conn: sqlite3.Connection, data: str) -> None:
+    """Persist context JSON in the database."""
+    with conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO context (key, data) VALUES ('state', ?)",
+            (data,),
+        )
+
+
+def load_context_db(conn: sqlite3.Connection) -> str | None:
+    """Load context JSON from the database if available."""
+    row = conn.execute("SELECT data FROM context WHERE key='state'").fetchone()
+    if row is None:
+        return None
+    return row[0] if isinstance(row, tuple) else row["data"]
+

--- a/db/init_db.py
+++ b/db/init_db.py
@@ -45,6 +45,11 @@ CREATE TABLE IF NOT EXISTS messages (
     timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY(project_id) REFERENCES projects(id)
 );
+
+CREATE TABLE IF NOT EXISTS context (
+    key TEXT PRIMARY KEY,
+    data TEXT
+);
 """
 
 def init_db(db_path: Path) -> None:

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -12,6 +12,7 @@ from .wand import WandWindow
 from .agent_creator import AgentCreatorDialog
 from .tool_editor import ToolEditorDialog
 from .agent_manager import AgentManagerDialog
+from .context_viewer import ContextWindow
 
 __all__ = [
     "LoginWindow",
@@ -28,4 +29,5 @@ __all__ = [
     "AgentCreatorDialog",
     "ToolEditorDialog",
     "AgentManagerDialog",
+    "ContextWindow",
 ]

--- a/gui/context_viewer.py
+++ b/gui/context_viewer.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+from PySide6 import QtWidgets, QtCore
+
+
+class ContextWindow(QtWidgets.QWidget):
+    """Simple viewer for the global context state."""
+
+    def __init__(self, path: Path) -> None:
+        super().__init__()
+        self.path = path
+        self.setWindowTitle("Context State")
+
+        self.text = QtWidgets.QPlainTextEdit(readOnly=True)
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(self.text)
+
+        self.timer = QtCore.QTimer(self)
+        self.timer.timeout.connect(self.load)
+        self.timer.start(1000)
+        self.load()
+
+    def load(self) -> None:  # pragma: no cover - file IO
+        if self.path.exists():
+            try:
+                self.text.setPlainText(self.path.read_text(encoding="utf-8"))
+            except Exception:
+                self.text.setPlainText("")
+        else:
+            self.text.setPlainText("<no context>")

--- a/gui/dashboard.py
+++ b/gui/dashboard.py
@@ -40,6 +40,7 @@ class Dashboard(QtWidgets.QMainWindow):
         self.chat_btn = QtWidgets.QPushButton("Open Chat")
         self.code_btn = QtWidgets.QPushButton("View Code")
         self.workspace_btn = QtWidgets.QPushButton("Workspace")
+        self.context_btn = QtWidgets.QPushButton("Context")
         self.roadmap_btn = QtWidgets.QPushButton("Roadmap")
         self.status_btn = QtWidgets.QPushButton("View Status")
         self.tasks_btn = QtWidgets.QPushButton("Manage Tasks")
@@ -68,6 +69,7 @@ class Dashboard(QtWidgets.QMainWindow):
         layout.addWidget(self.chat_btn)
         layout.addWidget(self.code_btn)
         layout.addWidget(self.workspace_btn)
+        layout.addWidget(self.context_btn)
         layout.addWidget(self.roadmap_btn)
         layout.addWidget(self.tasks_btn)
         layout.addWidget(self.agents_btn)
@@ -90,6 +92,7 @@ class Dashboard(QtWidgets.QMainWindow):
         self.chat_btn.clicked.connect(self.open_chat)
         self.code_btn.clicked.connect(self.open_code)
         self.workspace_btn.clicked.connect(self.open_workspace)
+        self.context_btn.clicked.connect(self.open_context)
         self.roadmap_btn.clicked.connect(self.open_roadmap)
         self.status_btn.clicked.connect(self.view_status)
         self.settings_btn.clicked.connect(self.open_settings)
@@ -144,6 +147,13 @@ class Dashboard(QtWidgets.QMainWindow):
                 QtWidgets.QMessageBox.information(
                     self, "Workspace", "No workspace available for this project"
                 )
+
+    def open_context(self) -> None:
+        from core.context import CONTEXT_FILE
+        from .context_viewer import ContextWindow
+
+        win = ContextWindow(CONTEXT_FILE)
+        win.show()
 
     def open_wand(self) -> None:
         project_id = self.selected_project_id()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,23 @@
+from core.context import load_context, save_context, append_entry, ContextState
+from db.init_db import init_db
+from db import load_context_db, save_context_db
+import sqlite3
+
+
+def test_context_file_ops(tmp_path):
+    path = tmp_path / "ctx.json"
+    state = load_context(path)
+    assert state.history == []
+    state.history.append({"msg": "hi"})
+    save_context(state, path)
+    state2 = load_context(path)
+    assert state2.history[0]["msg"] == "hi"
+
+
+def test_context_db(tmp_path):
+    db_path = tmp_path / "db.sqlite"
+    init_db(db_path)
+    conn = sqlite3.connect(db_path)
+    save_context_db(conn, '{"foo": 1}')
+    data = load_context_db(conn)
+    assert "foo" in data


### PR DESCRIPTION
## Summary
- add context engine module with JSON/DB support
- show context in dashboard via new widget
- persist context to database
- update docs and changelog
- create tests for context engine

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b549ff90832ea1b092c37bfea30a