### PR TITLE
Add tool execution

### DIFF
--- a/core/tools.py
+++ b/core/tools.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Dict
+import subprocess
 
 TOOL_REGISTRY: Dict[str, dict] = {}
 
@@ -13,3 +14,20 @@ def register_tool(name: str, spec: dict) -> None:
 def is_tool_registered(name: str) -> bool:
     """Return True if the tool name is registered."""
     return name in TOOL_REGISTRY
+
+
+def get_tool(name: str) -> dict | None:
+    """Return a tool specification from the registry."""
+    return TOOL_REGISTRY.get(name)
+
+
+def run_tool(name: str, params: str = "") -> str:
+    """Execute a registered tool and return its output."""
+    spec = get_tool(name)
+    if not spec:
+        raise ValueError(f"Tool {name} not registered")
+    command = spec.get("command", "")
+    base_params = spec.get("params", "")
+    cmd = f"{command} {base_params} {params}".strip()
+    result = subprocess.run(cmd, capture_output=True, text=True, shell=True)
+    return result.stdout.strip() or result.stderr.strip()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,6 @@
 from core.tool_store import add_tool, load_tools, remove_tool
 from plugins.tools_loader import Plugin
-from core.tools import TOOL_REGISTRY
+from core.tools import TOOL_REGISTRY, register_tool, run_tool
 
 
 def test_add_tool(tmp_path):
@@ -23,3 +23,10 @@ def test_remove_tool(tmp_path):
     add_tool({"name": "fmt", "description": "", "command": "black", "params": ""}, path)
     remove_tool("fmt", path)
     assert load_tools(path) == []
+
+
+def test_run_tool_echo(tmp_path):
+    TOOL_REGISTRY.clear()
+    register_tool("echo", {"command": "echo", "params": ""})
+    output = run_tool("echo", "hello")
+    assert output.strip() == "hello"


### PR DESCRIPTION
## Summary
- implement `run_tool` utility to execute registered tools
- provide `get_tool` helper
- test running a simple echo command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887f5990d48832eacb9b864cd17f3a5