### PR TITLE
Implement immediate tool registration

### DIFF
--- a/gui/tool_editor.py
+++ b/gui/tool_editor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from PySide6 import QtWidgets
 
 from core.tool_store import add_tool
+from core.tools import register_tool
 
 
 class ToolEditorDialog(QtWidgets.QDialog):
@@ -38,6 +39,7 @@ class ToolEditorDialog(QtWidgets.QDialog):
         }
         try:
             add_tool(tool)
+            register_tool(name, tool)
         except ValueError as exc:
             QtWidgets.QMessageBox.warning(self, "Tool", str(exc))
             return

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,12 @@
 from core.tool_store import add_tool, load_tools, remove_tool
 from plugins.tools_loader import Plugin
 from core.tools import TOOL_REGISTRY, register_tool, run_tool
+import pytest
+try:
+    from PySide6 import QtWidgets
+    from gui.tool_editor import ToolEditorDialog
+except Exception as exc:  # pragma: no cover - skip if Qt not installed
+    QtWidgets = None
 
 
 def test_add_tool(tmp_path):
@@ -30,3 +36,22 @@ def test_run_tool_echo(tmp_path):
     register_tool("echo", {"command": "echo", "params": ""})
     output = run_tool("echo", "hello")
     assert output.strip() == "hello"
+
+
+def test_tool_editor_registers(monkeypatch):
+    if QtWidgets is None:
+        pytest.skip("Qt not available")
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    TOOL_REGISTRY.clear()
+    saved = {}
+
+    def fake_add(tool):
+        saved.update(tool)
+
+    monkeypatch.setattr("gui.tool_editor.add_tool", fake_add)
+    monkeypatch.setattr(QtWidgets.QMessageBox, "information", lambda *a, **k: None)
+    dlg = ToolEditorDialog()
+    dlg.name_edit.setText("mytool")
+    dlg.save()
+    assert saved.get("name") == "mytool"
+    assert "mytool" in TOOL_REGISTRY


### PR DESCRIPTION
## Summary
- register tools immediately when saved in the tool editor
- test that ToolEditorDialog registers tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688835e9715c832e906afeafb15c8c7b