### PR TITLE
Add universal settings dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ Die Datenbank wird bei Erststart automatisch erzeugt.
 - **Task-Panel mit Agentenzuordnung**
 - **Code-Viewer mit Syntaxhighlighting**
 - **Mikrofonbutton für Spracheingabe**
-- **API-Key Einstellungen in der GUI**
+- **Einstellungsdialog f\u00fcr OpenRouter und GitHub Tokens**
 - **Adminpanel zur Benutzerverwaltung**
-- **Projektlöschung und Einstellungen nur für Admins**
+- **Projektlöschung nur für Admins**
 
 ---
 
@@ -149,7 +149,7 @@ Die Datenbank wird bei Erststart automatisch erzeugt.
 - Lokale Speicherung (keine Cloud)
  - Passwort-Hashing mit `bcrypt`
 - API-Key-Handling sicher in Datei
-- Nur Admin darf Projekte löschen, Konfiguration ändern
+- Nur Admin darf Projekte löschen
 
 ---
 
@@ -161,6 +161,7 @@ Die Datenbank wird bei Erststart automatisch erzeugt.
 - Node.js ≥ 18
 - Claude-Flow CLI installiert
 - OpenRouter API-Key
+- GitHub PAT (optional)
 
 ### Build mit PyInstaller
 

--- a/config.json
+++ b/config.json
@@ -1,5 +1,8 @@
 {
   "db_path": ".trynix/trynix.db",
   "log_dir": ".trynix/logs",
-  "tts_enabled": true
+  "workspace_dir": "workspace",
+  "tts_enabled": true,
+  "github_user": "",
+  "github_token": ""
 }

--- a/core/config.py
+++ b/core/config.py
@@ -8,6 +8,8 @@ class Config:
     log_dir: Path = Path('.trynix/logs')
     workspace_dir: Path = Path('workspace')
     tts_enabled: bool = True
+    github_user: str | None = None
+    github_token: str | None = None
 
     @classmethod
     def load(cls, path: Path | str) -> 'Config':
@@ -19,6 +21,8 @@ class Config:
                 log_dir=Path(data.get('log_dir', cls.log_dir)),
                 workspace_dir=Path(data.get('workspace_dir', cls.workspace_dir)),
                 tts_enabled=data.get('tts_enabled', cls.tts_enabled),
+                github_user=data.get('github_user'),
+                github_token=data.get('github_token'),
             )
         return cls()
 
@@ -31,6 +35,8 @@ class Config:
                     'log_dir': str(self.log_dir),
                     'workspace_dir': str(self.workspace_dir),
                     'tts_enabled': self.tts_enabled,
+                    'github_user': self.github_user,
+                    'github_token': self.github_token,
                 },
                 indent=2,
             )

--- a/gui/dashboard.py
+++ b/gui/dashboard.py
@@ -75,8 +75,8 @@ class Dashboard(QtWidgets.QMainWindow):
         layout.addWidget(self.agents_btn)
         layout.addWidget(self.status_btn)
         layout.addWidget(self.status_label)
+        layout.addWidget(self.settings_btn)
         if role == "admin":
-            layout.addWidget(self.settings_btn)
             layout.addWidget(self.delete_btn)
             layout.addWidget(self.admin_btn)
         self.setCentralWidget(central)
@@ -215,9 +215,6 @@ class Dashboard(QtWidgets.QMainWindow):
         )
 
     def open_settings(self) -> None:
-        if self.role != "admin":
-            QtWidgets.QMessageBox.warning(self, "Access", "Admins only")
-            return
         win = SettingsWindow()
         win.exec()
 

--- a/gui/settings.py
+++ b/gui/settings.py
@@ -16,12 +16,21 @@ class SettingsWindow(QtWidgets.QDialog):
             self.key_edit.setText(load_api_key())
         except Exception:
             pass
+        self.github_user_edit = QtWidgets.QLineEdit()
+        if CONFIG.github_user:
+            self.github_user_edit.setText(CONFIG.github_user)
+        self.github_token_edit = QtWidgets.QLineEdit()
+        self.github_token_edit.setEchoMode(QtWidgets.QLineEdit.Password)
+        if CONFIG.github_token:
+            self.github_token_edit.setText(CONFIG.github_token)
         self.tts_check = QtWidgets.QCheckBox("Enable Queen TTS")
         self.tts_check.setChecked(CONFIG.tts_enabled)
         save_btn = QtWidgets.QPushButton("Save")
 
         layout = QtWidgets.QFormLayout(self)
         layout.addRow("OpenRouter API Key", self.key_edit)
+        layout.addRow("GitHub Username", self.github_user_edit)
+        layout.addRow("GitHub Token", self.github_token_edit)
         layout.addRow(self.tts_check)
         layout.addWidget(save_btn)
 
@@ -29,6 +38,8 @@ class SettingsWindow(QtWidgets.QDialog):
 
     def save(self) -> None:
         save_api_key(self.key_edit.text())
+        CONFIG.github_user = self.github_user_edit.text().strip() or None
+        CONFIG.github_token = self.github_token_edit.text().strip() or None
         CONFIG.tts_enabled = self.tts_check.isChecked()
         CONFIG.save(CONFIG_PATH)
         QtWidgets.QMessageBox.information(self, "Settings", "Saved")

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -77,7 +77,7 @@ def test_dashboard_permissions(monkeypatch, tmp_path):
     assert row is not None
 
 
-def test_settings_permission(monkeypatch, tmp_path):
+def test_settings_access(monkeypatch, tmp_path):
     import pytest
     try:
         from PySide6 import QtWidgets
@@ -92,8 +92,15 @@ def test_settings_permission(monkeypatch, tmp_path):
 
     dash = Dashboard(conn, user_id=1, username="user", role="user")
 
-    warnings = []
-    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", lambda *a, **k: warnings.append(True))
+    flags = []
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", lambda *a, **k: flags.append("warn"))
+
+    class Dummy:
+        def exec(self):
+            flags.append("exec")
+
+    monkeypatch.setattr("gui.dashboard.SettingsWindow", Dummy)
 
     dash.open_settings()
-    assert warnings
+    assert "warn" not in flags
+    assert "exec" in flags


### PR DESCRIPTION
## Summary
- expose a settings button for all users
- allow storing GitHub credentials in config
- update the settings dialog
- document tokens in README
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68890c3a031c832ebc99b3eb1ac3d34e